### PR TITLE
DM-17794: For auxTel use visit rather than seqNum

### DIFF
--- a/bin/createCalibs_ci_lsst
+++ b/bin/createCalibs_ci_lsst
@@ -63,7 +63,7 @@ for camera in $cameras; do
 
     case $camera in
 	auxTel)
-	    biasIds="seqNum=28..36"
+	    biasIds="visit=2018092000028..2018092000036"
 	    configs="isr.overscanNumLeadingColumnsToSkip=20 isr.doDark=False"
 	    ;;
 	imsim)


### PR DESCRIPTION
seqNum works by fluke but is not part of the raw file specification
and would need dayObs for uniqueness.
Visit constrains things properly.